### PR TITLE
Fix pry debugger link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Emacs Lisp Module to add [pry debugger](http://pryrepl.org/) support to [realgud](http://github.com/rocky/emacs-dbgr).
+Emacs Lisp Module to add [pry debugger](https://github.com/nixme/pry-debugger) support to [realgud](http://github.com/rocky/emacs-dbgr).


### PR DESCRIPTION
Seems like the link http://pryrepl.org/ doesn't exist.